### PR TITLE
Incorporate multi-sample core from triplet pipeline

### DIFF
--- a/R/DensityEstimator.R
+++ b/R/DensityEstimator.R
@@ -164,7 +164,9 @@ Gibbs.subclone.density.est <- function(burden, GS.data, pngFile, density.smooth 
   }else{
     post.ints <- array(NA, c(512, post.burn.in.stop - post.burn.in.start + 1))
     xx=array(NA,c(1,512))
-    range=c(floor(min(burden)*10)-1,ceiling(max(burden[,1])*10)+1)/10
+    burden[is.infinite(burden)] = NA
+    burden[is.nan(burden)] = NA
+    range=c(floor(min(burden, na.rm=T)*10)-1,ceiling(max(burden[,1], na.rm=T)*10)+1)/10
   }
   
   #no.density.points=1000
@@ -255,12 +257,16 @@ Gibbs.subclone.density.est.nd <- function(burden, GS.data, density.smooth = 0.1,
   wts[,1] <- V.h.cols[,1]
   wts[,2] <- V.h.cols[,2] * (1-V.h.cols[,1])
   for (i in 3:dim(wts)[2]) {wts[,i] <- apply(1-V.h.cols[,1:(i-1)], MARGIN=1, FUN=prod) * V.h.cols[,i]}
-  
+ 
+  #DCW conversion from Inf / nan to na added 100417
+  burden[is.infinite(burden)] = NA
+  burden[is.nan(burden)] = NA
+
   num.timepoints = NCOL(burden)
   gridsize=rep(64,num.timepoints)
   range = array(NA,c(num.timepoints,2))
   for(n in 1:num.timepoints){
-    range[n,] = c(floor(min(burden[,1])*10)-2,ceiling(max(burden[,1])*10)+2)/10
+    range[n,] = c(floor(min(burden[,1], na.rm=T)*10)-2,ceiling(max(burden[,1], na.rm=T)*10)+2)/10
     #don't calculate density for outliers (should only be applied when burden is subclonal fraction)
     if(!is.na(max.burden) && range[n,2] > max.burden){
       range[n,2] = max.burden
@@ -387,6 +393,7 @@ Gibbs.subclone.density.est.nd <- function(burden, GS.data, density.smooth = 0.1,
     median.density[array(indices,c(1,num.timepoints))] = median(post.ints[cbind(array(rep(indices,each=no.samples),c(no.samples,num.timepoints)),1:no.samples)])
     lower.CI[array(indices,c(1,num.timepoints))] = quantile(post.ints[cbind(array(rep(indices,each=no.samples),c(no.samples,num.timepoints)),1:no.samples)],probs=0.05)
   }
+  print("finished calculating median and 95% CI")
   
   return(list(range=range, gridsize=gridsize, median.density=median.density, lower.CI=lower.CI))    
 }

--- a/R/DirichletProcessClustering.R
+++ b/R/DirichletProcessClustering.R
@@ -795,7 +795,10 @@ DirichletProcessClustering <- function(mutCount, WTCount, totalCopyNumber, copyN
   save(file=file.path(output_folder, paste(samplename, "_gsdata.RData", sep="")), GS.data)
   
   # nD dataset, plot sample versus sample
-  if (ncol(mutCount) > 1) {
+  if (ncol(mutCount) > 5) {
+	  print("Found more than 5 samples, cannot estimate density. Please use the triplet to estimate density and assign mutations. Stopping now")
+	  q(save="no")
+  } else if (ncol(mutCount) > 1) {
     ########################
     # Plot density and Assign mutations to clusters - nD
     ########################

--- a/R/PlotDensities.R
+++ b/R/PlotDensities.R
@@ -232,12 +232,13 @@ plotnD = function(xvals, yvals, zvals, subclonal.fraction_x, subclonal.fraction_
     yvals = data.matrix(yvals[yvals<=max.plotted.value])
   } else {
     # Set dynamic range based on the subclonal fraction data
-    range=list(c(floor(min(subclonal.fraction_x)*10)-1,ceiling(max(subclonal.fraction_x)*10)+1)/10, 
-               c(floor(min(subclonal.fraction_y)*10)-1,ceiling(max(subclonal.fraction_y)*10)+1)/10)
+    range=list(c(floor(min(subclonal.fraction_x, na.rm=T)*10)-1,ceiling(max(subclonal.fraction_x, na.rm=T)*10)+1)/10, 
+               c(floor(min(subclonal.fraction_y, na.rm=T)*10)-1,ceiling(max(subclonal.fraction_y, na.rm=T)*10)+1)/10)
   }
 
   #plot.data = cbind(data[[i]]$subclonal.fraction,data[[j]]$subclonal.fraction)
   plot.data = cbind(subclonal.fraction_x, subclonal.fraction_y)
+  plot.data = plot.data[!is.na(rowSums(plot.data)),]
   if(!is.na(max.plotted.value)) {
     plot.data = plot.data[plot.data[,1]<=max.plotted.value & plot.data[,2]<=max.plotted.value,]
   }


### PR DESCRIPTION
This PR contains all the differences between regular DPC and the triplet pipeline core functions, such that the triplet pipeline no longer requires any functions to be overloaded.

Have gone through the code line-by-line, this should contain all differences and testing here has not revealed any problems. However, it would be good to verify this independently.

One major change in behaviour is that the pipeline no longer attempts to estimate density for more than 5 samples as that will fail anyway.